### PR TITLE
Fix inventory positioning

### DIFF
--- a/game/engine.py
+++ b/game/engine.py
@@ -14,7 +14,7 @@ class Game:
     def __init__(self, scherm):
         self.scherm = scherm
         self.font = pygame.font.SysFont("consolas", 24)
-        self.monsters = self.monsters = monsterlijst
+        self.monsters = monsterlijst
         self.huidig_monster = self.monsters[0]
         self.vraagbron = []  # Nog geen vragen beschikbaar tot een eiland gekozen wordt
         self.vraag = {"vraag": "🗺️ Kies een eiland op de kaart!", "antwoord": "", "hint": ""}
@@ -47,7 +47,6 @@ class Game:
         self.reset_knop = None
         self.inventaris_knop_rect = pygame.Rect(700, 250, 200, 35)
         self.huidig_eiland = None
-        self.kaart_afbeelding = pygame.image.load(resource_path('Landkaart.png'))  # Relatief pad
         self.eilanden = [
             {"naam": "Limitanie", "rect": pygame.Rect(437, 117, 350, 100)},
             {"naam": "Integralia", "rect": pygame.Rect(1100, 270, 350, 100)},

--- a/game/teken.py
+++ b/game/teken.py
@@ -102,7 +102,7 @@ def teken_game(game):
         game.inventory_rects = []  # resetten elke frame
         for i, item in enumerate(game.inventory):
             tekst = game.font.render(f"- {item['naam']}", True, (220, 220, 220))
-            rect = tekst.get_rect(topleft=(520, y_inv + 40 + i * 30))
+            rect = tekst.get_rect(topleft=(920, y_inv + 40 + i * 30))
             game.scherm.blit(tekst, rect.topleft)
             game.inventory_rects.append((rect, item))
     # 🔘 Kladblokknop


### PR DESCRIPTION
## Summary
- fix double assignment of monster list
- avoid loading the map twice
- place inventory items inside the inventory box

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_683ffda18900832a8eeab8f73952b70e