### PR TITLE
Add boss monster mechanic

### DIFF
--- a/game/engine.py
+++ b/game/engine.py
@@ -95,11 +95,27 @@ class Game:
     def volgende_monster(self):
         # Volgende monster pakken (of random)
         self.huidig_monster = random.choice(self.monsters)
+
+        # Automatische overwinning als speler het speciale item bezit
+        if getattr(self.huidig_monster, "is_boss", False):
+            self.huidig_monster.progress = 0
+            for item in list(self.inventory):
+                if item["naam"] == self.huidig_monster.special_item:
+                    self.inventory.remove(item)
+                    self.feedback = f"🏆 {item['naam']} verslaat {self.huidig_monster.naam}!"
+                    self.goud += self.huidig_monster.goud
+                    if hasattr(self.huidig_monster, 'xp'):
+                        self.geef_xp(self.huidig_monster.xp)
+                    self.huidig_monster.verslagen = True
+                    pygame.time.set_timer(pygame.USEREVENT, 1500)
+                    return
+
         # Gebruik de juiste vragenbron afhankelijk van het gekozen eiland
         if self.vraagbron:
             self.vraag = self.huidig_monster.geef_vraag(self.vraagbron)
         else:
             self.vraag = {"vraag": "🗺️ Kies een eiland op de kaart!", "antwoord": "", "hint": ""}
+
         self.invoer = ""
         self.feedback = ""
         self.antwoord_gegeven = False

--- a/game/items.py
+++ b/game/items.py
@@ -19,6 +19,13 @@ basis_winkelvoorraad = [
     {"naam": "Sceptor van Stelsels", "prijs": 13}
 ]
 
+# Speciale items om bazen te verslaan
+basis_winkelvoorraad.extend([
+    {"naam": "Kroon Sleutel", "prijs": 50},
+    {"naam": "Ifrit Amulet", "prijs": 70},
+    {"naam": "Log Sleutel", "prijs": 90},
+])
+
 # Unieke items per eiland. Elke lijst bevat voorbeelden uit de
 # categorieën wapens, voedsel, trinkets, armor en draken.
 eiland_winkels = {

--- a/game/monsters.py
+++ b/game/monsters.py
@@ -9,6 +9,21 @@ class Monster:
 
     def geef_vraag(self, vragenlijst):
         return vragenlijst[self.vraag_index]
+
+
+class BossMonster(Monster):
+    """Speciale monsterklasse voor bazen."""
+
+    def __init__(self, naam, vraag_indices, goud, loot, xp, special_item):
+        super().__init__(naam, vraag_indices[0], goud, loot, xp)
+        self.vraag_indices = vraag_indices
+        self.special_item = special_item
+        self.progress = 0
+        self.is_boss = True
+
+    def geef_vraag(self, vragenlijst):
+        index = self.vraag_indices[self.progress]
+        return vragenlijst[index]
 monsterlijst = [
     Monster("Algebraïsche Gier", 0, 10, "Roestig Zwaard van Rekenkracht", 10),
     Monster("Haakjes-Hydra", 1, 15, "Verdedigende Breukenschild", 12),
@@ -32,3 +47,31 @@ monsterlijst = [
     Monster("Oplos-Oger", 19, 24, "X-mark Zwaard", 48),
 
 ]
+
+# Voeg drie bazen toe die meerdere vragen vereisen
+monsterlijst.extend([
+    BossMonster(
+        "Kwadratuur Koning",
+        [0, 1, 2],
+        100,
+        "Kroon der Congruentie",
+        100,
+        "Kroon Sleutel",
+    ),
+    BossMonster(
+        "Integrale Ifrit",
+        [3, 4, 5],
+        150,
+        "Vlam van Volledigheid",
+        150,
+        "Ifrit Amulet",
+    ),
+    BossMonster(
+        "Logaritmische Lord",
+        [6, 7, 8],
+        200,
+        "Scepter der Schalen",
+        200,
+        "Log Sleutel",
+    ),
+])

--- a/game/update.py
+++ b/game/update.py
@@ -112,16 +112,38 @@ def update_game(game):
                 juist_antwoord = game.vraag["antwoord"].replace(" ", "").lower()
                 speler_antwoord = game.invoer.replace(" ", "").lower()
                 if speler_antwoord == juist_antwoord:
-                    game.feedback = f"✅ Correct! Je hebt {game.huidig_monster.goud} goud verdiend!"
-                    game.huidig_monster.verslagen = True
-                    game.antwoord_gegeven = True
-                    game.goud += game.huidig_monster.goud
-                    # Geef XP voor monster
-                    if hasattr(game.huidig_monster, 'xp'):
-                        game.geef_xp(game.huidig_monster.xp)
-                    pygame.time.set_timer(pygame.USEREVENT, 1500)  # 1.5 sec wachten op nieuw monster
+                    if getattr(game.huidig_monster, 'is_boss', False):
+                        game.huidig_monster.progress += 1
+                        if game.huidig_monster.progress >= len(game.huidig_monster.vraag_indices):
+                            game.feedback = f"✅ Boss verslagen! Je hebt {game.huidig_monster.goud} goud verdiend!"
+                            game.huidig_monster.verslagen = True
+                            game.antwoord_gegeven = True
+                            game.goud += game.huidig_monster.goud
+                            if hasattr(game.huidig_monster, 'xp'):
+                                game.geef_xp(game.huidig_monster.xp)
+                            pygame.time.set_timer(pygame.USEREVENT, 1500)
+                            game.huidig_monster.progress = 0
+                        else:
+                            resterend = len(game.huidig_monster.vraag_indices) - game.huidig_monster.progress
+                            game.feedback = f"✅ Correct! Nog {resterend} te gaan"
+                            game.vraag = game.huidig_monster.geef_vraag(game.vraagbron)
+                            game.invoer = ""
+                    else:
+                        game.feedback = f"✅ Correct! Je hebt {game.huidig_monster.goud} goud verdiend!"
+                        game.huidig_monster.verslagen = True
+                        game.antwoord_gegeven = True
+                        game.goud += game.huidig_monster.goud
+                        if hasattr(game.huidig_monster, 'xp'):
+                            game.geef_xp(game.huidig_monster.xp)
+                        pygame.time.set_timer(pygame.USEREVENT, 1500)
                 else:
-                    game.feedback = "❌ Helaas, dat is niet juist..."
+                    if getattr(game.huidig_monster, 'is_boss', False):
+                        game.huidig_monster.progress = 0
+                        game.feedback = "❌ Fout! Begin opnieuw."
+                        game.vraag = game.huidig_monster.geef_vraag(game.vraagbron)
+                        game.invoer = ""
+                    else:
+                        game.feedback = "❌ Helaas, dat is niet juist..."
             elif event.key == pygame.K_BACKSPACE:
                 game.invoer = game.invoer[:-1]
             else:


### PR DESCRIPTION
## Summary
- introduce `BossMonster` class for multi-question bosses
- add three boss monsters to the roster
- add special boss items to shop inventory
- auto-defeat bosses when player has the matching item
- require three correct answers in a row to beat a boss

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684577d7399c832a846f477a1099b74f