### PR TITLE
Automated exe build via GitHub Actions

### DIFF
--- a/.github/workflows/build-exe.yml
+++ b/.github/workflows/build-exe.yml
@@ -1,0 +1,34 @@
+name: Build EXE
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pyinstaller
+      - name: Run tests
+        run: pytest -q
+      - name: Build exe
+        run: pyinstaller main.py --onefile --windowed \
+          --add-data "Goudstukken.png;." \
+          --add-data "Landkaart.png;." \
+          --add-data "winkelier.png;." \
+          --add-data "assets;assets"
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: Edu-Dungeon-exe
+          path: dist/main.exe

--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ pyinstaller main.py --onefile --windowed --add-data "Goudstukken.png;." --add-da
 ```
 De `.exe` vind je in de `dist/` map.
 
+### Automatische builds
+
+Bij iedere push naar `main` wordt via GitHub Actions automatisch een nieuwe
+versie van het spel als `.exe` gebouwd. Het resultaat kun je downloaden als
+artifact van de workflow.
+
 ## Besturing
 
 - **Muis**: Klik op knoppen, eilanden, winkelitems, etc.


### PR DESCRIPTION
## Summary
- add workflow to build Windows executable on pushes to main
- document automatic exe builds in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684aa7a58a50832aa556f4b2eb6b0569